### PR TITLE
multiline reply headers de

### DIFF
--- a/test/fixtures/email_multiline_reply_headers_de.txt
+++ b/test/fixtures/email_multiline_reply_headers_de.txt
@@ -1,0 +1,14 @@
+I get proper rendering as well.
+
+Sent a magnificent torch of pixels
+
+Am Mi., 5. Feb. 2020 um 17:58 Uhr schrieb Company Questions
+<questions@company.com>:
+
+> Was this caching related or fixed already?  I get proper rendering here.
+>
+> ![](https://img.skitch.com/20111216-m9munqjsy112yqap5cjee5wr6c.jpg)
+>
+> ---
+> Reply to this email directly or view it on GitHub:
+> https://github.com/github/github/issues/2278#issuecomment-3182418

--- a/test/test.js
+++ b/test/test.js
@@ -107,6 +107,18 @@ exports.test_deals_with_multiline_reply_headers = function(test){
 	test.done();
 };
 
+exports.test_deals_with_multiline_reply_headers_de = function(test){
+    let email = get_email("email_multiline_reply_headers_de");
+
+    let fragments = email.getFragments();
+
+	test.equal(true, /^I get/.test(fragments[0]));
+	test.equal(true,/^Am/.test(fragments[1]));
+	test.equal(true, /Was this/.test(fragments[1]));
+
+	test.done();
+};
+
 exports.test_email_with_italian = function(test) {
 	let email = get_email("email_7");
 


### PR DESCRIPTION
DO NOT MERGE

This demonstrates an issue with German Gmail multi line reply headers. It's not an issue with English Gmail multi line reply headers as you can see from the test above `test_deals_with_multiline_reply_headers` and `test/fixtures/email_6.txt`

The issue isn't fixed yet.