### PR TITLE
fix: Improve "Original Message" signature

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -38,7 +38,7 @@ class RegexList {
       /^\+{2,4}$/, // Separator
       /^\={2,4}$/, // Separator
       /^________________________________$/, // Separator
-      /^-{1,10}Original message-{1,10}$/,
+      /^-{1,10} ?Original message ?-{1,10}$/i,
       /^Sent from (?:\s*.+)$/, // en
       /^Get Outlook for (?:\s*.+).*/m, // en
       /^Cheers,?!?$/mi, // en


### PR DESCRIPTION
Some email clients capitalize "Message" for example or add some extract space between the words and the dashes (ProtonMail does this for example).

This is what ProtonMail adds at the end
```
------- Original Message -------
(original message here)
```