### PR TITLE
Update regex.js

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -27,7 +27,8 @@ class RegexList {
       /^\s*([a-z]{3,4}\.\s[\s\S]+\sskrev\s[\s\S]+:)$/m, // DATE skrev NAME <EMAIL>:
       /^([0-9]{2}).([0-9]{2}).(20[0-9]{2})(.*)(([0-9]{2}).([0-9]{2}))(.*)\"( *)<(.*)>( *):$/m, // DD.MM.20YY HH:II NAME <EMAIL>
       /^[0-9]{2}:[0-9]{2}(.*)[0-9]{4}(.*)\"( *)<(.*)>( *):$/, // HH:II, DATE, NAME <EMAIL>:
-      /^(.*)[0-9]{4}(.*)from(.*)<(.*)>:$/
+      /^(.*)[0-9]{4}(.*)from(.*)<(.*)>:$/,
+      /^-{1,10}Original (M|m)essage-{1,10}$/
     ]);
 
     this.signatureRegex = this.buildRe2([
@@ -38,7 +39,6 @@ class RegexList {
       /^\+{2,4}$/, // Separator
       /^\={2,4}$/, // Separator
       /^________________________________$/, // Separator
-      /^-{1,10}Original message-{1,10}$/,
       /^Sent from (?:\s*.+)$/, // en
       /^Get Outlook for (?:\s*.+).*/m, // en
       /^Cheers,?!?$/mi, // en


### PR DESCRIPTION
"---Original message---" is not a signature. It's a Quote Header.

Modified the regular expression to "(M|m)essage" to account for cases where 'Message' is capitalized.