### PR TITLE
Add support for (multiline) datetime in German "schrieb:" quote header

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -17,7 +17,7 @@ class RegexList {
       /^(在[\s\S]+写道：)$/m, // > 在 DATE, TIME, NAME 写道：
       /^(20[0-9]{2}\..+\s작성:)$/m, // DATE TIME NAME 작성:
       /^(20[0-9]{2}\/.+のメッセージ:)$/m, // DATE TIME、NAME のメッセージ:
-      /^(.+\s<.+>\sschrieb:)$/m, // NAME <EMAIL> schrieb:
+      /^(.+\s<.+>\sschrieb(?:\sam\s.+)?(?:\n.+)?:)$/m, // NAME <EMAIL> schrieb( am DATETIME)?: (with support for some datetime parts to optionally be on a newline)
       /^(.+\son.*at.*wrote:)$/m, // NAME on DATE wrote:
       /^\s*(From\s?:.+\s?\n?\s*[\[|<].+[\]|>])/m, // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With support whitespace before start and before <)
       /^\s*(Von\s?:.+\s?\n?\s*[\[|<].+[\]|>])/m, // "Von: NAME <EMAIL>" OR "Von : NAME <EMAIL>" OR "Von : NAME<EMAIL>"(With support whitespace before start and before <)

--- a/test/fixtures/email_gmail_split_datetime.txt
+++ b/test/fixtures/email_gmail_split_datetime.txt
@@ -1,0 +1,12 @@
+Fusce bibendum, quam hendrerit sagittis tempor, dui turpis tempus erat, pharetra sodales ante sem sit amet metus.
+Nulla malesuada, orci non vulputate lobortis, massa felis pharetra ex, convallis consectetur ex libero eget ante.
+Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenatis ex a rutrum.
+Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,
+et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.
+
+Aa Bb Cc <abc@abc.org> schrieb am So., 23.
+Juni 2024, 21:08:
+
+> Hi CBA!
+>
+> ABC has sent you a message on ABC

--- a/test/test.js
+++ b/test/test.js
@@ -399,6 +399,17 @@ exports.test_email_gmail = function(test) {
 	test.done();
 }
 
+exports.test_email_gmail_split_datetime = function (test) {
+	let email = get_email("email_gmail_split_datetime");
+
+	let fragments = email.getFragments();
+
+	test.equal(COMMON_FIRST_FRAGMENT, fragments[0].toString().trim());
+	test.equal(2, fragments.length);
+
+	test.done();
+}
+
 exports.text_email_reply_header = function(test) {
 	let email = get_email("email_reply_header");
 


### PR DESCRIPTION
I noticed a German email with a datetime specified in the quote header, in a way that was as of yet unhandled.

This PR handles the following two new cases, by example.

**Datetime with newline**: I observed this one, see also the included test email fixture.
```
Aa Bb Cc <abc@abc.org> schrieb am So., 23.
Juni 2024, 21:08:
```

**Datetime without newline:** I didn't observe this one, but it might just as well exist.
```
Aa Bb Cc <abc@abc.org> schrieb am So., 23. Juni 2024, 21:08:
```


The following case was already handled before, and is still handled with this regex change:
```
Aa Bb Cc <abc@abc.org> schrieb:
```