### PR TITLE
feat: add italian signature

### DIFF
--- a/lib/regex.js
+++ b/lib/regex.js
@@ -82,6 +82,9 @@ class RegexList {
 
       // ES
       /^Enviado desde (?:\s*.+)$/, // es,
+      
+      // IT
+      /^-*\s*(In\sdata\s.+\s.+\n?scritto:{0,1})\s{0,1}-*$/m, // it,
 
       // NL
       /^Verzonden vanaf (?:\s*.+)$/, // nl - e.g. Verzonden vanaf (Outlook voor Android<https://aka.ms/12345>|mijn iPad)

--- a/test/fixtures/email_italian.txt
+++ b/test/fixtures/email_italian.txt
@@ -1,0 +1,9 @@
+Fusce bibendum, quam hendrerit sagittis tempor, dui turpis tempus erat, pharetra sodales ante sem sit amet metus.
+Nulla malesuada, orci non vulputate lobortis, massa felis pharetra ex, convallis consectetur ex libero eget ante.
+Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenatis ex a rutrum.
+Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,
+et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.
+
+In data 11 ottobre 2017 21:11:31 schrieb "John Doe - Stripe" <s.test.i@mail.stripe.com> ha scritto:
+
+Buongiorno!

--- a/test/fixtures/email_italian.txt
+++ b/test/fixtures/email_italian.txt
@@ -4,6 +4,6 @@ Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenat
 Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,
 et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.
 
-In data 11 ottobre 2017 21:11:31 schrieb "John Doe - Stripe" <s.test.i@mail.stripe.com> ha scritto:
+In data 11 ottobre 2017 21:11:31 "John Doe - Stripe" <s.test.i@mail.stripe.com> ha scritto:
 
 Buongiorno!

--- a/test/test.js
+++ b/test/test.js
@@ -303,6 +303,16 @@ exports.test_email_finnish = function(test) {
   test.done();
 };
 
+exports.test_email_italian = function(test) {
+  let email = get_email("email_italian");
+
+  let fragments = email.getFragments();
+
+  test.equal(COMMON_FIRST_FRAGMENT, fragments[0].toString().trim());
+
+  test.done();
+};
+
 exports.test_email_with_correct_signature = function(test) {
   let email = get_email("correct_sig");
 


### PR DESCRIPTION
This PR adds an Italian signature coming from the AquaMail Android app, having the format "In data {DATE} {SENDER} ha scritto:". I used the original Italian regex ("Il {DATE} ...") from the top of the regex.js file and adopted it accordingly.

As it is quite generic I can imagine that it catches as well a couple of other clients as well.