### PR TITLE
fix: adding regex for german outlook

### DIFF
--- a/lib/regex.ts
+++ b/lib/regex.ts
@@ -60,7 +60,8 @@ class RegexList {
       /^(.*)[0-9]{4}(.*)from(.*)<(.*)>:$/,
       /^-{1,12} ?(O|o)riginal (M|m)essage ?-{1,12}$/i,
       /^-{1,12} ?(O|o)prindelig (B|b)esked ?-{1,12}$/i,
-      /^-{1,12} ?(M|m)essage d\'origine ?-{1,12}$/i
+      /^-{1,12} ?(M|m)essage d\'origine ?-{1,12}$/i,
+      /^-{1,12} ?(U|u)rsprüngliche (N|n)achricht ?-{0,12}$/i
     ]);
 
     this.signatureRegex = this.buildSafeRegexes([

--- a/test/fixtures/email_german_outlook.txt
+++ b/test/fixtures/email_german_outlook.txt
@@ -1,0 +1,13 @@
+Fusce bibendum, quam hendrerit sagittis tempor, dui turpis tempus erat, pharetra sodales ante sem sit amet metus.
+Nulla malesuada, orci non vulputate lobortis, massa felis pharetra ex, convallis consectetur ex libero eget ante.
+Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenatis ex a rutrum.
+Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,
+et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.
+
+-----Ursprüngliche Nachricht-----
+Von: Max Mustermann <max.m@beispiel.de>
+An: Erika Musterfrau <e.m@beispiel.de>
+Betreff: Ihre Anfrage
+Datum: 25.11.2025 15:00
+
+This is the original message content.

--- a/test/test.js
+++ b/test/test.js
@@ -288,6 +288,16 @@ export function test_email_german_3(test) {
   test.done();
 };
 
+export function test_email_german_outlook(test) {
+  let email = get_email("email_german_outlook");
+
+  let fragments = email.getFragments();
+
+  test.equal(COMMON_FIRST_FRAGMENT, fragments[0].toString().trim());
+
+  test.done();
+};
+
 export function test_email_gmail_no(test) {
   let email = get_email("email_norwegian_gmail");
 


### PR DESCRIPTION
I needed to handle German Outlook replies so I added an extra Regex.

I could not run the tests locally due to an issue with Nodeunit importing modules but I manually ran a test like the following:

```
const emailText = `
Fusce bibendum, quam hendrerit sagittis tempor, dui turpis tempus erat, pharetra sodales ante sem sit amet metus.
Nulla malesuada, orci non vulputate lobortis, massa felis pharetra ex, convallis consectetur ex libero eget ante.
Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenatis ex a rutrum.
Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,
et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.

-----Ursprüngliche Nachricht-----
Von: Max Mustermann <max.m@beispiel.de>
An: Erika Musterfrau <e.m@beispiel.de>
Betreff: Ihre Anfrage
Datum: 25.11.2025 15:00

This is the original message content.
`

const parsedEmail = new EmailReplyParser().read(emailText)

console.log(parsedEmail.getVisibleText())
```
Results:
<img width="1159" height="199" alt="image" src="https://github.com/user-attachments/assets/ce62bc9b-3ac6-4cba-9c59-e6683af63b28" />
