### PR TITLE
fix: adding fix for newline after < in german gmails

### DIFF
--- a/lib/regex.ts
+++ b/lib/regex.ts
@@ -34,14 +34,13 @@ class RegexList {
       /^-*\s*(On\s.+\s.+\n?wrote:{0,1})\s{0,1}-*$/m, // On DATE, NAME <EMAIL> wrote:
       /^-*\s*(Le\s.+\s.+\n?écrit\s?:{0,1})\s{0,1}-*$/m, // Le DATE, NAME <EMAIL> a écrit :
       /^-*\s*(El\s.+\s.+\n?escribió:{0,1})\s{0,1}-*$/m, // El DATE, NAME <EMAIL> escribió:
-      /^-*\s*(Il\s.+\s.+\n?scritto:{0,1})\s{0,1}-*$/m,  // Il DATE, NAME <EMAIL> ha scritto:
-      /^-*\s*(Em\s.+\s.+\n?escreveu:{0,1})\s{0,1}-*$/m,  // Em DATE, NAME <EMAIL> ha escreveu:
-      /^\s*(Am\s.+\s)\n?\n?schrieb.+\s?(\[|<).+(\]|>):$/m, // Am DATE schrieb NAME <EMAIL>:
+      /^-*\s*(Il\s.+\s.+\n?scritto:{0,1})\s{0,1}-*$/m, // Il DATE, NAME <EMAIL> ha scritto:
+      /^-*\s*(Em\s.+\s.+\n?escreveu:{0,1})\s{0,1}-*$/m, // Em DATE, NAME <EMAIL> ha escreveu:
       /^\s*(Op\s[\s\S]+?\n?schreef[\s\S]+:)$/m, // Il DATE, schreef NAME <EMAIL>:
       /^\s*((W\sdniu|Dnia)\s[\s\S]+?(pisze|napisał(\(a\))?):)$/mu, // W dniu DATE, NAME <EMAIL> pisze|napisał:
       /^\s*(Den\s.+\s\n?skrev\s.+:)$/m, // Den DATE skrev NAME <EMAIL>:
       /^\s*(pe\s.+\s.+\n?kirjoitti:)$/m, // pe DATE NAME <EMAIL> kirjoitti:
-      /^\s*(Am\s.+\sum\s.+\s\n?schrieb\s.+:)$/m, // Am DATE um TIME schrieb NAME:
+      /^\s*(Am\s.+\s\n?\n?schrieb.+\s?((\[|<)\n?.+(\]|>))?):$/m, // Am DATE schrieb NAME <EMAIL>: OR Am DATE um TIME schrieb NAME <EMAIL>: (with optional newline after <)
       /^\s*(ср\,\s.+\n? г\. в\s.+,\s.+[\[|<].+[\]|>]:)$/m, // ср, DATE г. в TIME, NAME <EMAIL>:
       /^(在[\s\S]+写道：)$/m, // > 在 DATE, TIME, NAME 写道：
       /^(20[0-9]{2}\..+\s작성:)$/m, // DATE TIME NAME 작성:

--- a/test/fixtures/email_gmail_split_line_from_german.txt
+++ b/test/fixtures/email_gmail_split_line_from_german.txt
@@ -1,0 +1,13 @@
+Fusce bibendum, quam hendrerit sagittis tempor, dui turpis tempus erat, pharetra sodales ante sem sit amet metus.
+Nulla malesuada, orci non vulputate lobortis, massa felis pharetra ex, convallis consectetur ex libero eget ante.
+Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenatis ex a rutrum.
+Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,
+et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.
+
+Am Fr., 28. Nov. 2025 um 15:57 Uhr schrieb Test Mailer <
+testing@testing.com>:
+
+> Test
+> Respond
+> <https://tracking.fake.company/wf/open?upn=23f98s9v8dgvusadf8gvhj92834trh982kPaN-2Bzz2b2l67UT96AH2NcL0wRl3s-2BKsQIu0komyhpMwWHavdLtWB0qPad224t2BEF-2Fkxlasdbvasdbvasdfbasdfv 2Bscvasdfgvasdfg333-6785674351uDlO-2BvbD8rsFaei8jRo0-2BxBRNGl9-2BPpnkPQ6twZMlUlAivCMpPM3116GPX5hl90xoINZv5a1SE5cqVYN4zjyJ4xNJXtKwXP36yUpvTGk1D-2FJd-2F7gihrcC3tUNIwlwvp5qrd1jAj2R-2BIgVqrUPSCjPyu-2BTNJe2uJ6789fsdfsdef423234343-2B3-2FyNSl-2Fp20lDXiZgCmg5xjrqdeuSGGc-2BW-2B5Qf7u-2BFrVBz8WaEvldRKMZ0pFqkxIgk7W3O4F2I8cLZBekLW12d5S8-3D> 
+>

--- a/test/test.js
+++ b/test/test.js
@@ -456,6 +456,17 @@ export function test_email_gmail(test) {
   test.done();
 }
 
+export function test_email_gmail_split_line_german(test) {
+  let email = get_email("email_gmail_split_line_from_german");
+
+  let fragments = email.getFragments();
+
+  test.equal(COMMON_FIRST_FRAGMENT, fragments[0].toString().trim());
+  test.equal(2, fragments.length);
+
+  test.done();
+}
+
 export function text_email_reply_header(test) {
   let email = get_email("email_reply_header");
 


### PR DESCRIPTION
There was already an addition for the English version of this problem. Where a newline is added after the < before the email  in the 'from' line (I guess on long email addresses only?).

I also consolidated the two German Gmail regexes into one that handles the following formats:

Am DATE um TIME Uhr schrieb NAME <\nEMAIL>: (new line after first <)
Am DATE um TIME Uhr schrieb NAME <EMAIL>:
Am DATE um TIME schrieb NAME:
Am DATE schrieb NAME <EMAIL>:

I could not run the tests just to an import issue but ran a separate test for them with the following script:

```javascript
// Am DATE um TIME Uhr schrieb NAME <EMAIL>:  (new line after first <)
//
const testDE1 = `
Blah blah blah.

Am Fr., 28. Nov. 2025 um 15:57 Uhr schrieb Test Mailer <
testing@testing.com>:

> Test
`

// Am DATE um TIME Uhr schrieb NAME <EMAIL>:
//
const testDE2 = `
Blah blah blah.

Am Fr., 28. Nov. 2025 um 15:57 Uhr schrieb Test Mailer <testing@testing.com>:

> Test
`

// Am DATE um TIME schrieb NAME:
//
const testDE3 = `
Blah blah blah.

Am Fr., 28. Nov. 2025 um 15:57 schrieb Test Mailer:

> Test
`

// Am DATE schrieb NAME <EMAIL>:
//
const testDE4 = `
Blah blah blah.

Am Fr., 28. Nov. 2025 schrieb Test Mailer <testing@testing.com>:

> Test
`


const emails = [testDE1, testDE2, testDE3, testDE4]

emails.forEach((e) => {
  console.log(new EmailReplyParser().parseReply(e).trim())
})

// output
//
// Blah blah blah.
// Blah blah blah.
// Blah blah blah.
// Blah blah blah.
```

Please run the original tests if you can.