### PR TITLE
feat: add parse options to ignore separators from signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ console.log(parser.parseReply(emailContent));
 // Output: "Hi there,\n\nI appreciate your help with this issue."
 ```
 
+### Parse Options
+
+`read`, `parseReply`, and `parseReplied` accept an optional second argument:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `excludeSignatureSeparators` | `boolean` | `false` | Ignore visual separator lines (`--`, `__`, `==`, `++`, etc.) when detecting signatures. Language-specific signatures like "Sent from my iPhone" are still detected. |
+
+``` javascript
+const parser = new EmailReplyParser();
+
+// Default: "--" line triggers signature detection
+parser.parseReply("Hello\n\n--\nJohn");
+// => "Hello\n"
+
+// With option: "--" line is kept as visible content
+parser.parseReply("Hello\n\n--\nJohn", { excludeSignatureSeparators: true });
+// => "Hello\n\n--\nJohn"
+```
+
 ## Contributing
 
 Feel free to fork this project and submit fixes. We may adapt your code to fit the codebase.

--- a/lib/emailreplyparser.ts
+++ b/lib/emailreplyparser.ts
@@ -11,6 +11,7 @@
 
 // PROJECT: LIB
 import EmailParser from "./parser/emailparser.js";
+import type { ParseOptions } from "./parser/emailparser.js";
 
 /**
  * EmailReplyParser
@@ -19,22 +20,22 @@ class EmailReplyParser {
   /**
    * Parse an email
    */
-  public read(text: string) {
-    return new EmailParser().parse(text);
+  public read(text: string, options?: ParseOptions) {
+    return new EmailParser().parse(text, options);
   }
 
   /**
    * Parse a reply
    */
-  public parseReply(text: string) {
-    return this.read(text).getVisibleText();
+  public parseReply(text: string, options?: ParseOptions) {
+    return this.read(text, options).getVisibleText();
   }
 
   /**
    * Parse a replied email
    */
-  public parseReplied(text: string) {
-    return this.read(text).getQuotedText();
+  public parseReplied(text: string, options?: ParseOptions) {
+    return this.read(text, options).getQuotedText();
   }
 }
 

--- a/lib/parser/emailparser.ts
+++ b/lib/parser/emailparser.ts
@@ -24,17 +24,23 @@ const LEADING_NEWLINE_REGEX = /^\n/g;
 const CRLF_NEWLINE_REGEX = /\r\n/g;
 const NEWLINE_REGEX = /\n/g;
 
+export interface ParseOptions {
+  excludeSignatureSeparators?: boolean;
+}
+
 /**
  * EmailParser
  */
 class EmailParser {
   private fragments: FragmentDTO[];
+  private options: ParseOptions;
 
   /**
    * Constructor
    */
   constructor() {
     this.fragments = [];
+    this.options = {};
   }
 
   /**
@@ -77,7 +83,8 @@ class EmailParser {
   /**
    * Parse an email
    */
-  parse(text: string) {
+  parse(text: string, options?: ParseOptions) {
+    this.options = options || {};
     text = text.replace(CRLF_NEWLINE_REGEX, "\n");
     text = this.fixBrokenSignatures(text);
 
@@ -210,7 +217,11 @@ class EmailParser {
   isSignature(line) {
     let text = this.stringReverse(line);
 
-    return RegexList.signatureRegex.some((regex) => {
+    let regexes = this.options.excludeSignatureSeparators
+      ? RegexList.signatureRegex
+      : [...RegexList.separatorSignatureRegex, ...RegexList.signatureRegex];
+
+    return regexes.some((regex) => {
       return regex.test(text);
     });
   }

--- a/lib/regex.ts
+++ b/lib/regex.ts
@@ -22,6 +22,7 @@ class RegexList {
   RE2: typeof RE2;
   hasRE2: boolean;
   quoteHeadersRegex: RegExp[];
+  separatorSignatureRegex: RegExp[];
   signatureRegex: RegExp[];
 
   /**
@@ -64,14 +65,16 @@ class RegexList {
       /^-{1,12} ?(U|u)rsprüngliche (N|n)achricht ?-{0,12}$/i
     ]);
 
-    this.signatureRegex = this.buildSafeRegexes([
+    this.separatorSignatureRegex = this.buildSafeRegexes([
       /^\s*-{2,4}$/, // Separator
       /^\s*_{2,4}$/, // Separator
       /^-- $/, // Separator
       /^\+{2,4}$/, // Separator
       /^\={2,4}$/, // Separator
-      /^________________________________$/, // Separator
+      /^________________________________$/ // Separator
+    ]);
 
+    this.signatureRegex = this.buildSafeRegexes([
       // EN
       /^Sent from (?:\s*.+)$/, // en
       /^Get Outlook for (?:\s*.+).*/m, // en

--- a/test/test.js
+++ b/test/test.js
@@ -13,10 +13,10 @@ Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenat
 Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,\n\
 et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.';
 
-function get_email(name) {
+function get_email(name, parseOptions) {
   var data = fs.readFileSync(__dirname + "/fixtures/" + name + ".txt", "utf-8");
 
-  return new EmailReplyParser().read(data);
+  return new EmailReplyParser().read(data, parseOptions);
 }
 
 export function test_reads_simple_body(test){
@@ -917,5 +917,58 @@ export function test_parseReplied_with_multiple_quotes(test) {
   test.equal(true, /Hi folks/.test(quoted));
   test.equal(true, /riak-users mailing list/.test(quoted));
   
+  test.done();
+}
+
+export function test_excludeSignatureSeparators_keeps_separator_visible(test) {
+  let opts = { excludeSignatureSeparators: true };
+
+  // correct_sig has "--" separator — should NOT be a signature with option
+  let email = get_email("correct_sig", opts);
+  let fragments = email.getFragments();
+
+  test.equal(1, fragments.length);
+  test.equal(false, fragments[0].isSignature());
+  test.equal(true, /correct -- signature/.test(fragments[0].toString()));
+  test.equal(true, /rick/.test(fragments[0].toString()));
+
+  test.done();
+}
+
+export function test_excludeSignatureSeparators_default_unchanged(test) {
+  // Without option, correct_sig should still detect signature as before
+  let email = get_email("correct_sig");
+  let fragments = email.getFragments();
+
+  test.equal(2, fragments.length);
+  test.equal(false, fragments[0].isSignature());
+  test.equal(true, fragments[1].isSignature());
+
+  test.done();
+}
+
+export function test_excludeSignatureSeparators_still_detects_phrase_signatures(test) {
+  let email = get_email("email_sent_from", { excludeSignatureSeparators: true });
+  let fragments = email.getFragments();
+
+  // "Sent from" should still be detected as signature
+  test.equal(true, fragments.some(f => f.isSignature()));
+
+  test.done();
+}
+
+export function test_parseReply_with_excludeSignatureSeparators(test) {
+  var data = "Hello world\n\n--\nJohn Doe";
+  var parser = new EmailReplyParser();
+
+  var defaultReply = parser.parseReply(data);
+  var optionReply = parser.parseReply(data, { excludeSignatureSeparators: true });
+
+  // Default: separator triggers signature, only "Hello world" visible
+  test.equal("Hello world\n", defaultReply);
+
+  // With option: separator not a signature, entire email visible
+  test.equal("Hello world\n\n--\nJohn Doe", optionReply);
+
   test.done();
 }


### PR DESCRIPTION
Solves this issue: https://github.com/crisp-oss/email-reply-parser/issues/41

I encountered this issue when parsing some property listing website emails, where they use `---` as separators within their emails, e.g a Zoopla.co.uk email will look like this (shortened version). 

The `parse` method now had options to alter its behavior, and I added solely `excludeSignatureSeparators`. 

```
Dear team at XYZ
You have a new=20
    Tenant enquiry.

TENANT ENQUIRY FROM XYZ VIA ZOOPLA

Please find below an enquiry from XYZ
Please respond to this enquiry promptly to maximise your chances of converting this lead.

---

APPLICANT'S DETAILS

......

---

Full address 

.....
```